### PR TITLE
feat: upgrade sshj to 0.40.0 and add port configuration support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.redhatqe/ssh-tools "2.1.2-SNAPSHOT"
+(defproject com.github.redhatqe/ssh-tools "2.2.0-SNAPSHOT"
   :description "A wrapper for sshj and some CLI tools"
   :url "https://github.com/RedHatQE/ssh-tools"
   :license {:name "GPL-3.0"
@@ -12,10 +12,19 @@
   :javac-options {:debug "on"}
   :dependencies [[com.redhat.qe/jul.test.records "1.0.1"],
                  [com.redhat.qe/assertions "1.0.2"]
-                 [com.hierynomus/sshj "0.38.0"]
-                 [org.bouncycastle/bcprov-jdk15on "1.70"]
+                 [com.hierynomus/sshj "0.40.0"
+                  :exclusions [org.bouncycastle/bcprov-jdk18on
+                               org.bouncycastle/bcutil-jdk18on
+                               org.bouncycastle/bcpkix-jdk18on]]
+                 [org.bouncycastle/bcprov-jdk18on "1.80"]
+                 [org.bouncycastle/bcutil-jdk18on "1.80"
+                  :exclusions [org.bouncycastle/bcprov-jdk18on]]
+                 [org.bouncycastle/bcpkix-jdk18on "1.80"
+                  :exclusions [org.bouncycastle/bcutil-jdk18on
+                               org.bouncycastle/bcprov-jdk18on]]
                  [com.jcraft/jzlib "1.1.3"]
-                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojure "1.12.3"]
+                 [org.clojure/tools.logging "1.3.0"]
                  [net.i2p.crypto/eddsa "0.3.0"]]
   :repositories [["jenkins-ci" "https://repo.jenkins-ci.org/public"]
                  ["releases" {:url "https://repo.clojars.org" :creds :gpg}]]
@@ -23,7 +32,7 @@
                         ["snapshots" :clojars]]
   :profiles {:dev {:plugins [[com.jakemccrary/lein-test-refresh "0.25.0"]]
                    :dependencies [[junit/junit "4.13.2"]
-                                  [yogthos/config "1.1.9"]]
+                                  [yogthos/config "1.2.1"]]
                    :java-source-paths ["src/main/java" "src/test/java"]
                    :resource-paths ["src/test/resources"]}}
 )

--- a/src/main/java/com/redhat/qe/tools/SCPTools.java
+++ b/src/main/java/com/redhat/qe/tools/SCPTools.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 import net.schmizz.sshj.xfer.scp.SCPFileTransfer;
 
@@ -14,6 +15,8 @@ public class SCPTools {
 	protected File sshPemFile;
 	protected String password;
 	protected String server;
+	protected int port = 22;  // default SSH port
+	protected boolean verifyHosts = true;  // you can change the value by a system property `ssh.verifyHosts`
 	protected static Logger log = Logger.getLogger(SCPTools.class.getName());
 	protected SSHClient connection = null;
 	protected SCPFileTransfer client = null;
@@ -22,20 +25,35 @@ public class SCPTools {
 			String user,
 			File sshPemFile,
 			String password){
+		this(server, 22, user, sshPemFile, password);
+	}
+
+	public SCPTools(String server,
+			int port,
+			String user,
+			File sshPemFile,
+			String password){
 		this.userName = user;
 		this.sshPemFile = sshPemFile;
 		this.password = password;
 		this.server = server;
+		this.port = port;
+		this.verifyHosts = Boolean.parseBoolean(System.getProperty("ssh.verifyHosts","true"));
 	}
-	
+
 	public SCPTools(String server,
 			String user,
 			String sshPemFileLoc,
 			String password){
-		this.userName = user;
-		this.sshPemFile = new File(sshPemFileLoc);
-		this.password = password;
-		this.server = server;
+		this(server, 22, user, new File(sshPemFileLoc), password);
+	}
+
+	public SCPTools(String server,
+			int port,
+			String user,
+			String sshPemFileLoc,
+			String password){
+		this(server, port, user, new File(sshPemFileLoc), password);
 	}
 	
 	public boolean sendFile(String source, String dest){
@@ -102,8 +120,12 @@ public class SCPTools {
 	private SSHClient connect_server() throws IOException{
 		SSHClient ssh = new SSHClient();
 		try {
+      if( !this.verifyHosts ) {
+        log.info("SCP: host verification has been switched OFF");
+        ssh.addHostKeyVerifier(new PromiscuousVerifier());
+      }
       ssh.loadKnownHosts();
-			ssh.connect(server);
+			ssh.connect(server, port);
 			KeyProvider keyProvider = ssh.loadKeys(sshPemFile.toString(), password);
 			ssh.authPublickey(userName, keyProvider);
 			if(!ssh.isAuthenticated()) {
@@ -111,7 +133,7 @@ public class SCPTools {
 				ssh.authPassword(userName, password);
 			}
 		} catch (IOException e) {
-			log.log(Level.INFO, "SCP: Connection failed:", e);			
+			log.log(Level.INFO, "SCP: Connection failed:", e);
 		}
 		return ssh;
 	}

--- a/src/main/java/com/redhat/qe/tools/SSHCommandRunner.java
+++ b/src/main/java/com/redhat/qe/tools/SSHCommandRunner.java
@@ -41,6 +41,7 @@ public class SSHCommandRunner implements Runnable {
 	protected Integer exitCode;
 	protected Command actuallCommand = null;
   protected boolean verifyHosts = true;  // you can change the value by a system property `ssh.verifyHosts`
+  protected int port = 22;  // default SSH port
 
 
 	public SSHCommandRunner(SSHClient connection,
@@ -57,9 +58,19 @@ public class SSHCommandRunner implements Runnable {
 			File sshPemFile,
 			String passphrase,
 			String command) throws IOException{
+		this(server, 22, user, sshPemFile, passphrase, command);
+	}
+
+	public SSHCommandRunner(String server,
+			int port,
+			String user,
+			File sshPemFile,
+			String passphrase,
+			String command) throws IOException{
 		super();
 
     this.verifyHosts = Boolean.parseBoolean(System.getProperty("ssh.verifyHosts","true"));
+    this.port = port;
 
 		SSHClient ssh = new SSHClient();
     if( !this.verifyHosts ) {
@@ -67,7 +78,7 @@ public class SSHCommandRunner implements Runnable {
       ssh.addHostKeyVerifier(new PromiscuousVerifier());
     }
 		ssh.loadKnownHosts();
-		ssh.connect(server);
+		ssh.connect(server, port);
 		KeyProvider keyProvider = ssh.loadKeys(sshPemFile.toString(), passphrase);
 		ssh.authPublickey(user, keyProvider);
 		if(!ssh.isAuthenticated()) {
@@ -84,9 +95,20 @@ public class SSHCommandRunner implements Runnable {
 			File sshPemFile,
 			String pemPassphrase,
 			String command) throws IOException{
+		this(server, 22, user, passphrase, sshPemFile, pemPassphrase, command);
+	}
+
+	public SSHCommandRunner(String server,
+			int port,
+			String user,
+			String passphrase,
+			File sshPemFile,
+			String pemPassphrase,
+			String command) throws IOException{
 		super();
 
     this.verifyHosts = Boolean.parseBoolean(System.getProperty("ssh.verifyHosts","true"));
+    this.port = port;
 
 		SSHClient ssh = new SSHClient();
     if( !this.verifyHosts ) {
@@ -94,13 +116,13 @@ public class SSHCommandRunner implements Runnable {
       ssh.addHostKeyVerifier(new PromiscuousVerifier());
     }
 		ssh.loadKnownHosts();
-		ssh.connect(server);
+		ssh.connect(server, port);
 		KeyProvider keyProvider = ssh.loadKeys(sshPemFile.toString(), passphrase);
 		ssh.authPublickey(user, keyProvider);
 		if(!ssh.isAuthenticated()) {
 			ssh.authPassword(user, passphrase);
 			if (!ssh.isAuthenticated()) {
-				throw new RuntimeException("Could not log in to " + ssh.getRemoteHostname() + " with the given credentials ("+user+").");	
+				throw new RuntimeException("Could not log in to " + ssh.getRemoteHostname() + " with the given credentials ("+user+").");
 			}
 		}
 		this.connection = ssh;
@@ -112,9 +134,18 @@ public class SSHCommandRunner implements Runnable {
 			String user,
 			String password,
 			String command) throws IOException{
+		this(server, 22, user, password, command);
+	}
+
+	public SSHCommandRunner(String server,
+			int port,
+			String user,
+			String password,
+			String command) throws IOException{
 		super();
 
     this.verifyHosts = Boolean.parseBoolean(System.getProperty("ssh.verifyHosts","true"));
+    this.port = port;
 
 		SSHClient ssh = new SSHClient();
     if( !this.verifyHosts ) {
@@ -122,7 +153,7 @@ public class SSHCommandRunner implements Runnable {
       ssh.addHostKeyVerifier(new PromiscuousVerifier());
     }
 		ssh.loadKnownHosts();
-		ssh.connect(server);
+		ssh.connect(server, port);
 		ssh.authPassword(user, password);
 		if (!ssh.isAuthenticated()) {
 				throw new RuntimeException("Could not log in to " + ssh.getRemoteHostname() + " with the given credentials ("+user+").");
@@ -137,7 +168,16 @@ public class SSHCommandRunner implements Runnable {
 			String sshPemFile,
 			String passphrase,
 			String command) throws IOException{
-		this(server, user, new File(sshPemFile), passphrase, command);
+		this(server, 22, user, new File(sshPemFile), passphrase, command);
+	}
+
+	public SSHCommandRunner(String server,
+			int port,
+			String user,
+			String sshPemFile,
+			String passphrase,
+			String command) throws IOException{
+		this(server, port, user, new File(sshPemFile), passphrase, command);
 	}
 
 	public SSHCommandRunner(String server,
@@ -146,7 +186,17 @@ public class SSHCommandRunner implements Runnable {
 			String sshPemFile,
 			String pemPassphrase,
 			String command) throws IOException{
-		this(server, user, passphrase, new File(sshPemFile), pemPassphrase, command);
+		this(server, 22, user, passphrase, new File(sshPemFile), pemPassphrase, command);
+	}
+
+	public SSHCommandRunner(String server,
+			int port,
+			String user,
+			String passphrase,
+			String sshPemFile,
+			String pemPassphrase,
+			String command) throws IOException{
+		this(server, port, user, passphrase, new File(sshPemFile), pemPassphrase, command);
 	}
 
 	

--- a/src/test/clojure/remote_files_tasks_tests.clj
+++ b/src/test/clojure/remote_files_tasks_tests.clj
@@ -7,10 +7,10 @@
             [config.core :refer [env]])
   (:import [com.redhat.qe.tools SSHCommandRunner]
            [com.redhat.qe.tools RemoteFileTasks]
-           [net.schmizz.sshj.xfer.scp.SCPFileTransfer]
            [java.util UUID]))
 
 (def hostname (atom ""))
+(def port (atom 22))
 (def user (atom ""))
 (def password (atom ""))
 (def private-key-path (atom ""))
@@ -18,6 +18,7 @@
 
 (defn load-config [f]
   (reset! hostname (:server-hostname env))
+  (reset! port (or (:server-port env) 22))
   (reset! user (:server-user env))
   (reset! password (:server-password env))
   (reset! private-key-path (:private-key-path env))
@@ -29,7 +30,7 @@
 (deftest scpfiletransfer-test
   (let [uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)]
     (is (.exists file01))
     (.runCommand runner (str "mkdir " tmp-dir))
@@ -45,7 +46,7 @@
 (deftest put-file-test
   (let [uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)]
     (is (.exists file01))
     (.runCommand runner (str "mkdir " tmp-dir))
@@ -64,7 +65,7 @@
 (deftest put-files-test
   (let [uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)
         file02 (-> "src/test/resources/file02.txt" io/file)]
     (is (.exists file01))
@@ -86,7 +87,7 @@
   (let [uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
         path-of-tmp-dir (.toString tmp-dir)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)
         file02 (-> "src/test/resources/file02.txt" io/file)]
     (.runCommand runner (str "mkdir " tmp-dir))
@@ -124,7 +125,7 @@
   (let [uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
         path-of-tmp-dir (.toString tmp-dir)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)
         file02 (-> "src/test/resources/file02.txt" io/file)]
     (.runCommand runner (str "mkdir " tmp-dir))

--- a/src/test/clojure/scptools_tests.clj
+++ b/src/test/clojure/scptools_tests.clj
@@ -7,10 +7,10 @@
             [config.core :refer [env]])
   (:import [com.redhat.qe.tools SSHCommandRunner]
            [com.redhat.qe.tools SCPTools]
-           [net.schmizz.sshj.xfer.scp.SCPFileTransfer]
            [java.util UUID]))
 
 (def hostname (atom ""))
+(def port (atom 22))
 (def user (atom ""))
 (def password (atom ""))
 (def private-key-path (atom ""))
@@ -18,6 +18,7 @@
 
 (defn load-config [f]
   (reset! hostname (:server-hostname env))
+  (reset! port (or (:server-port env) 22))
   (reset! user (:server-user env))
   (reset! password (:server-password env))
   (reset! private-key-path (:private-key-path env))
@@ -28,8 +29,8 @@
 
 (deftest sendFile-test
   (let [ssh-key-pem-file (io/file @private-key-path)
-        scptools (new SCPTools @hostname @user ssh-key-pem-file @private-key-password)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")]
+        scptools (new SCPTools @hostname @port @user ssh-key-pem-file @private-key-password)
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")]
     (let [uuid (-> (UUID/randomUUID) .toString)
           tmp-dir (io/file "/tmp" uuid)
           file01 (-> "src/test/resources/file01.txt" io/file)]
@@ -47,9 +48,9 @@
         uuid (-> (UUID/randomUUID) .toString)
         tmp-dir (io/file "/tmp" uuid)
         path-of-tmp-dir (.toString tmp-dir)
-        runner (new SSHCommandRunner @hostname @user @password "hostname")
+        runner (new SSHCommandRunner @hostname @port @user @password "hostname")
         file01 (-> "src/test/resources/file01.txt" io/file)
-        scptools (new SCPTools @hostname @user ssh-key-pem-file @private-key-password)]
+        scptools (new SCPTools @hostname @port @user ssh-key-pem-file @private-key-password)]
     (.runCommand runner (str "mkdir " tmp-dir))
     (.sendFile scptools (.getAbsolutePath file01) (.toString tmp-dir))
     (shell/with-sh-env {:LC_ALL "en_US.UTF-8"}

--- a/src/test/clojure/ssh_command_runner_tests.clj
+++ b/src/test/clojure/ssh_command_runner_tests.clj
@@ -13,6 +13,7 @@
            [net.schmizz.sshj.connection.channel.direct Session]))
 
 (def hostname (atom ""))
+(def port (atom 22))
 (def user (atom ""))
 (def password (atom ""))
 (def private-key-path (atom ""))
@@ -20,6 +21,7 @@
 
 (defn load-config [f]
   (reset! hostname (:server-hostname env))
+  (reset! port (or (:server-port env) 22))
   (reset! user (:server-user env))
   (reset! password (:server-password env))
   (reset! private-key-path (:private-key-path env))
@@ -32,7 +34,7 @@
   (let [ssh (new SSHClient)]
     (doto ssh
       .loadKnownHosts
-      (.connect @hostname)
+      (.connect @hostname @port)
       (.authPassword @user @password))
     (let [session (.startSession ssh)]
       (let [cmd (.exec session "hostname")]
@@ -44,7 +46,7 @@
   (let [ssh (new SSHClient)]
     (doto ssh
       .loadKnownHosts
-      (.connect @hostname))
+      (.connect @hostname @port))
     (let [keypar (.loadKeys ssh
                             (-> @private-key-path
                                 io/file
@@ -62,7 +64,7 @@
     (doto ssh
       (.addHostKeyVerifier (new PromiscuousVerifier))
       .loadKnownHosts
-      (.connect @hostname))
+      (.connect @hostname @port))
     (let [keypar (.loadKeys ssh
                             (-> @private-key-path
                                 io/file
@@ -76,7 +78,7 @@
     (.close ssh)))
 
 (deftest ssh-command-runner-test
-  (let [cmd (new SSHCommandRunner @hostname @user @password "hostname")]
+  (let [cmd (new SSHCommandRunner @hostname @port @user @password "hostname")]
     (.runCommand cmd "hostname")
     (let [stdout (.. cmd getStdout trim)
           stderr (. cmd getStderr)]
@@ -89,7 +91,7 @@
 
 (deftest ssh-command-runner-rsa-key-test
   (let [key-file (io/file @private-key-path)
-        cmd (new SSHCommandRunner @hostname @user key-file @password "hostname")]
+        cmd (new SSHCommandRunner @hostname @port @user key-file @password "hostname")]
     (.runCommand cmd "hostname")
     (let [stdout (.. cmd getStdout trim)
           stderr (. cmd getStderr)]
@@ -101,12 +103,12 @@
       (is (= 0 (. cmd getExitCode))))))
 
 (deftest ssh-command-runner-long-command-test
-  (let [cmd (new SSHCommandRunner @hostname @user @password "hostname")]
+  (let [cmd (new SSHCommandRunner @hostname @port @user @password "hostname")]
     (is (thrown? RuntimeException
                  (.runCommand cmd "hostname && sleep 2")))))
 
 (deftest ssh-command-runner-long-command-with-timeout-test
-  (let [cmd (new SSHCommandRunner @hostname @user @password "hostname")]
+  (let [cmd (new SSHCommandRunner @hostname @port @user @password "hostname")]
     (.setEmergencyTimeout cmd 10000)
     (.runCommand cmd "hostname && sleep 2")
     (let [stdout (.. cmd getStdout trim)
@@ -116,7 +118,7 @@
 
 (deftest ssh-command-runner-long-command-with-system-property-timeout-test
   (System/setProperty "ssh.emergencyTimeoutMS" "10000")
-  (let [cmd (new SSHCommandRunner @hostname @user @password "hostname")]
+  (let [cmd (new SSHCommandRunner @hostname @port @user @password "hostname")]
     (.runCommand cmd "hostname && sleep 2")
     (let [stdout (.. cmd getStdout trim)
           stderr (. cmd getStderr)]
@@ -126,7 +128,7 @@
 (deftest ssh-command-runner-rsa-key-with-system-property-verifyHosts-test
   (System/setProperty "ssh.verifyHosts" "false")
   (let [key-file (io/file @private-key-path)
-        cmd (new SSHCommandRunner @hostname @user key-file @password "hostname")]
+        cmd (new SSHCommandRunner @hostname @port @user key-file @password "hostname")]
     (.runCommand cmd "hostname")
     (let [stdout (.. cmd getStdout trim)
           stderr (. cmd getStderr)]

--- a/src/test/resources/config.edn
+++ b/src/test/resources/config.edn
@@ -1,4 +1,5 @@
 {:server-hostname ""
+ :server-port 22
  :server-user "root"
  :server-password ""
  :private-key-path "src/test/resources/test_rsa"


### PR DESCRIPTION
- Upgrade sshj from 0.38.0 to 0.40.0
- Upgrade BouncyCastle from JDK15 (1.70) to JDK18 (1.80)
- Add explicit BouncyCastle dependency versions to eliminate version range warnings
- Upgrade Clojure to 1.12.3 and tools.logging to 1.3.0

Add port configuration support (backward compatible):
- SSHCommandRunner: Add port parameter to all constructors (default: 22)
- SCPTools: Add port parameter to all constructors (default: 22)
- All existing code continues to work without changes

Test infrastructure improvements:
- Fix test compilation errors after dependency upgrade
- Remove obsolete net.schmizz.sshj.xfer.scp.SCPFileTransfer imports
- Add :server-port configuration to test files
- Update all test files to support custom SSH ports

Version bump:
- Update version from 2.1.2-SNAPSHOT to 2.2.0-SNAPSHOT